### PR TITLE
docs(slacker.web): Correct moduledocs information

### DIFF
--- a/lib/slacker/web.ex
+++ b/lib/slacker/web.ex
@@ -6,9 +6,7 @@ defmodule Slacker.Web do
   #   and provide any necessary parameters as a keyword list, ex:
 
   #     https://api.slack.com/methods/channels.setPurpose
-  #     Slacker.Web.channels_set_purpose(channel: "general", purpose: "let's waste time")
-
-  #   Your auth token will be automatically included for you.
+  #     Slacker.Web.channels_set_purpose("your_api_key", channel: "general", purpose: "let's waste time")
   # """
 
   alias Slacker.WebAPI


### PR DESCRIPTION
Correct the moduledocs for `Slacker.Web`.

It said that the API token would automagically be included for you, but it won't. Not passing the token results in errors where it treats the body params as the token instead, which obviously won't work. The
information is correct in the README.
